### PR TITLE
Fix gitignore patch

### DIFF
--- a/posts/2019-08-23-using-puppeteer-with-node2nix.md
+++ b/posts/2019-08-23-using-puppeteer-with-node2nix.md
@@ -73,7 +73,7 @@ Then go look for the `src` attribute defined in the `args` let-binding, and repl
     packageName = "puppeteer-node2nix";
     version = "1.0.0";
 -   src = ./.;
-+   src = pkgs.nix-gitignore.gitignoreSource [ ".git" ] ./.;
++   src = gitignoreSource [ ".git" ] ./.;
     dependencies = [
 ```
 


### PR DESCRIPTION
gitignoreSource argument should be used directly instead of trying to get it from pkgs.

Great work by the way ! I'll need this quite often !